### PR TITLE
phpcs 2.2 changes

### DIFF
--- a/Sniffs/Commenting/FileCommentSniff.php
+++ b/Sniffs/Commenting/FileCommentSniff.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Ensure that @author annotations contain email or URL
+ *
+ * PHP version 5
+ * 
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2011 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @class 
+ */
+class ENTB_Sniffs_Commenting_FileCommentSniff extends PEAR_Sniffs_Commenting_FileCommentSniff
+{
+    /**
+     * Process the author tag(s) that this header comment has.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param array                $tags      The tokens for these tags.
+     *
+     * @return void
+     */
+    protected function processAuthor(PHP_CodeSniffer_File $phpcsFile, array $tags)
+    {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tags as $tag) {
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                // No content.
+                continue;
+            }
+            $content = $tokens[($tag + 2)]['content'];
+            $local   = '\da-zA-Z-_+';
+            // Dot character cannot be the first or last character in the local-part.
+            $localMiddle = $local.'.\w';
+            $mailPattern = '['.$local.'](['.$localMiddle.']*['.$local.'])*@[\da-zA-Z][-.\w]*[\da-zA-Z]\.[a-zA-Z]{2,7})';
+            // allow simple urls
+            $urlPattern = 'https?\:\/\/[a-z]+[.]+[a-z]+[a-zA-Z\/]*';
+            if (preg_match('/^([^<]*)\s+<(('.$urlPattern.'|'.$mailPattern.')>$/', $content) === 0) {
+                $error = 'Content of the @author tag must be in the form "Display Name <username@example.com>"';
+                $phpcsFile->addError($error, $tag, 'InvalidAuthors');
+            }
+        }
+    }
+}

--- a/Sniffs/Commenting/FileCommentSniff.php
+++ b/Sniffs/Commenting/FileCommentSniff.php
@@ -39,7 +39,7 @@ class ENTB_Sniffs_Commenting_FileCommentSniff extends PEAR_Sniffs_Commenting_Fil
             // allow simple urls
             $urlPattern = 'https?\:\/\/[a-z]+[.]+[a-z]+[a-zA-Z\/]*';
             if (preg_match('/^([^<]*)\s+<(('.$urlPattern.'|'.$mailPattern.')>$/', $content) === 0) {
-                $error = 'Content of the @author tag must be in the form "Display Name <username@example.com>"';
+                $error = 'Content of the @author tag must be in the form "Display Name <Email|URL>"';
                 $phpcsFile->addError($error, $tag, 'InvalidAuthors');
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
        "GPL-3.0+"
   ],
   "require": {
-    "goatherd/phpcs_installer": "*"
   },
   "extra": {
     "phpcs-standard": "ENTB"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -34,6 +34,9 @@
  <rule ref="Zend.NamingConventions.ValidVariableName">
    <exclude name="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
  </rule>
+ <rule ref="PEAR">
+   <exclude name="PEAR.Commenting.ClassComment.InvalidAuthors"/>
+ </rule>
 
  <!-- LineLength rules are as relaxed as PSR2 (down from 80/120) -->
  <rule ref="Generic.Files.LineLength">


### PR DESCRIPTION
Makes way so we can upgrade phpcs to 2.2. Also replaces the ``@author`` sniff with one that supports URLs in the field (instead of email).

I'm removing ``goatherd/phpcs_installer`` since that has been deprecated and it is preferred to add the following script to ``composer.json``.

````js
"\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
````
I'll create a PR for that as soon as this is merged...