### PR TITLE
Modernize ENTB Sniffs

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -29,6 +29,8 @@
  <rule ref="Squiz.Commenting.EmptyCatchComment"/>
  <rule ref="PEAR.Commenting.ClassComment">
    <exclude name="PEAR.Commenting.ClassComment.InvalidAuthors"/>
+   <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
+   <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag"/>
  </rule>
  <rule ref="Squiz.Commenting.DocCommentAlignment"/>
  <rule ref="ENTB.NamingConventions.ValidInterfaceName"/>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -52,4 +52,14 @@
   </properties>
  </rule>
 
+ <!-- only use tags in class comment and not in file -->
+ <rule ref="ENTB.Commenting.FileComment">
+   <exclude name="ENTB.Commenting.FileComment.MissingVersion"/>
+   <exclude name="ENTB.Commenting.FileComment.MissingCategoryTag"/>
+   <exclude name="ENTB.Commenting.FileComment.MissingPackageTag"/>
+   <exclude name="ENTB.Commenting.FileComment.MissingAuthorTag"/>
+   <exclude name="ENTB.Commenting.FileComment.MissingLicenseTag"/>
+   <exclude name="ENTB.Commenting.FileComment.MissingLinkTag"/>
+ </rule>
+
 </ruleset>


### PR DESCRIPTION
We need to work on our Sniffer standard.

Have a look at libgraviton/graviton#18 and let me know if you need more changes.

Any pet peeves about our standards? Please take your time to tell me what they are we'll find a solution.

I'll keep this open until shortly before we merge libgraviton/graviton#18.